### PR TITLE
Fix constants for data pipeline deployment

### DIFF
--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -4,8 +4,8 @@ The backend architecture processes the time-series usage and global ranking snap
 
 # Tech Stack
 
--   Go
--   Python
+-   Go 1.17
+-   Python 3.9
 -   MongoDB
 -   AWS Lambda
 -   AWS Elastic Container Registry

--- a/docs/deployment_checklist.md
+++ b/docs/deployment_checklist.md
@@ -8,6 +8,7 @@
 
 -   [ ] Build Docker image using `push_data_extractor_image.sh`
 -   [ ] Deploy the new Docker image on AWS Lambda
+-   [ ] Ensure environment variables `MONGOURI` and `ENV` (`DEV`, `QA`, `PROD`) are set
 
 ## Server Source Checklist
 

--- a/src/data_pipeline/utils/constants.py
+++ b/src/data_pipeline/utils/constants.py
@@ -2,8 +2,17 @@
 from utils.env_configs import ENV
 
 # PS! terms
-FORMATS = ["gen8vgc2021series11", "gen8ou"]
-NUM_TEAMS = 10
+# gen8vgc2021series11 is a legacy format primarily for tests
+FORMATS = [
+    "gen8vgc2021series11",
+    "gen8vgc2022",
+    "gen8doublesou",
+    "gen8ou",
+    "gen8nationaldexag",
+    "gen8nationaldex",
+    "gen8anythinggoes",
+]
+NUM_TEAMS = 50
 MAX_USERS = 500
 NUM_PARTNERS = 5
 TEAM_SIZE = 6

--- a/src/server/controllers/utils/constants.go
+++ b/src/server/controllers/utils/constants.go
@@ -1,7 +1,8 @@
 package utils
 
 // PS! terms
-var Formats []string = []string{"gen8vgc2021series11", "gen8ou"}
+// gen8vgc2021series11 is a legacy format primarily for tests
+var Formats []string = []string{"gen8vgc2021series11", "gen8vgc2022", "gen8doublesou", "gen8ou", "gen8nationaldexag", "gen8nationaldex", "gen8anythinggoes"}
 
 // Usage Pipeline Type Enums
 type UsageType int


### PR DESCRIPTION
<!---
Taken from UBC Thunderbots: https://github.com/UBC-Thunderbots
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

Change # of teams to extract and valid formats by popularity.

### Testing Done

CI passes.

### Resolved Issues

<!--
    Link any issues that this PR resolved. Ex. `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

-   [ ] **Function & Class comments**: All function definitions should have comments, which are checked by the linters (ie. `pylint`).
-   [ ] **Remove all commented out code**
-   [ ] **Remove extra print statements**: for example, those just used for testing
-   [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request.
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
